### PR TITLE
Fix type errors in resume scoring

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -86,8 +86,9 @@ export default function Home() {
       }
     });
 
-    const score = jdWords.length > 0 ? Math.floor((matchCount / jdSet.size) * 100) : 0;
-    setScore(score);
+    const calculatedScore =
+      jdWords.length > 0 ? Math.floor((matchCount / jdSet.size) * 100) : 0;
+    setScore(calculatedScore);
     setMatchedKeywords(matched);
   };
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -68,14 +68,14 @@ export default function Home() {
       .toLowerCase()
       .replace(/[^\w\s]/g, '')
       .split(/\s+/)
-      .filter((word) => word.length > 2);
+      .filter((word: string) => word.length > 2);
 
     const resumeWords = resumeText
       .toLowerCase()
       .replace(/[^\w\s]/g, '')
       .split(/\s+/);
 
-    const jdSet = new Set(jdWords);
+    const jdSet = new Set<string>(jdWords);
     let matchCount = 0;
     const matched: string[] = [];
 
@@ -139,7 +139,8 @@ export default function Home() {
               rows={10}
               className="w-full p-4 border border-gray-300 rounded-xl bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
               value={jdText}
-              onChange={(e) => setJdText(e.target.value)}
+              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                setJdText(e.target.value)}
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- fix implicit `any` errors in `pages/index.tsx`
- annotate textarea change handler

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685552be349c83268f21ce294bc460fe