### PR TITLE
Add suggestions workflow

### DIFF
--- a/lib/openai.ts
+++ b/lib/openai.ts
@@ -26,3 +26,25 @@ Output:
 
   return completion.choices[0].message.content || '';
 }
+
+export async function suggestEdits(original: string, jd: string): Promise<string> {
+  const prompt = `
+You are an expert resume reviewer.
+Provide bullet point suggestions for improving the resume to better match the following job description.
+
+Job Description:
+${jd}
+
+Resume:
+${original}
+
+Output:
+`;
+
+  const completion = await openai.chat.completions.create({
+    messages: [{ role: 'user', content: prompt }],
+    model: 'gpt-4',
+  });
+
+  return completion.choices[0].message.content || '';
+}

--- a/pages/api/suggest.ts
+++ b/pages/api/suggest.ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { suggestEdits } from '../../lib/openai';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.setHeader('Allow', 'POST').status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  const { original, jd } = req.body as { original?: string; jd?: string };
+
+  if (!original || !jd) {
+    return res.status(400).json({ error: 'Missing resume or job description' });
+  }
+
+  try {
+    const suggestions = await suggestEdits(original, jd);
+    return res.status(200).json({ suggestions });
+  } catch (error) {
+    console.error('Suggest API Error:', error instanceof Error ? error.message : error);
+    return res.status(500).json({ error: 'Failed to generate suggestions' });
+  }
+}

--- a/pdfjs.d.ts
+++ b/pdfjs.d.ts
@@ -1,4 +1,3 @@
 // pdfjs.d.ts
 declare module 'pdfjs-dist/legacy/build/pdf';
-declare module 'pdfjs-dist/legacy/build/pdf.worker.entry';
 


### PR DESCRIPTION
## Summary
- generate edit suggestions using OpenAI
- add new /api/suggest endpoint
- update UI for suggesting and applying edits
- allow tailored resume download
- hide extracted resume text block

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685552be349c83268f21ce294bc460fe