### PR TITLE
Fix resume scoring by preserving original text

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,6 +8,7 @@ pdfjsLib.GlobalWorkerOptions.workerSrc = `https://cdnjs.cloudflare.com/ajax/libs
 
 export default function Home() {
   const [resumeText, setResumeText] = useState('');
+  const [originalResumeText, setOriginalResumeText] = useState('');
   const [jdText, setJdText] = useState('');
   const [score, setScore] = useState<number | null>(null);
   const [matchedKeywords, setMatchedKeywords] = useState<string[]>([]);
@@ -38,14 +39,19 @@ export default function Home() {
       const buffer = await file.arrayBuffer();
       const text = await extractTextFromPDF(buffer);
       setResumeText(text);
+      setOriginalResumeText(text);
     } else if (ext === 'docx') {
       const arrayBuffer = await file.arrayBuffer();
       const result = await mammoth.extractRawText({ arrayBuffer });
-      setResumeText(result.value || '');
+      const text = result.value || '';
+      setResumeText(text);
+      setOriginalResumeText(text);
     } else if (ext === 'txt') {
       const reader = new FileReader();
       reader.onload = () => {
-        setResumeText(reader.result?.toString() || '');
+        const text = reader.result?.toString() || '';
+        setResumeText(text);
+        setOriginalResumeText(text);
       };
       reader.readAsText(file);
     } else {
@@ -70,7 +76,7 @@ export default function Home() {
       .split(/\s+/)
       .filter((word: string) => word.length > 2);
 
-    const resumeWords = resumeText
+    const resumeWords = originalResumeText
       .toLowerCase()
       .replace(/[^\w\s]/g, '')
       .split(/\s+/);


### PR DESCRIPTION
## Summary
- keep original resume text in state on upload
- base scoring on the preserved original resume text

## Testing
- `npm run lint`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68568b2ee280832694e5185a8cff4a3e